### PR TITLE
fix: revert apps-engine version limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@oclif/plugin-help": "^2.2.0",
         "@oclif/plugin-not-found": "^1.2.2",
         "@rocket.chat/apps-compiler": "^0.4.1",
-        "@rocket.chat/apps-engine": "~1.50.0",
+        "@rocket.chat/apps-engine": "^1.50.0",
         "axios": "^1.6.0",
         "chalk": "^2.4.2",
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@oclif/plugin-help": "^2.2.0",
     "@oclif/plugin-not-found": "^1.2.2",
     "@rocket.chat/apps-compiler": "^0.4.1",
-    "@rocket.chat/apps-engine": "~1.50.0",
+    "@rocket.chat/apps-engine": "^1.50.0",
     "axios": "^1.6.0",
     "chalk": "^2.4.2",
     "chokidar": "^3.3.1",


### PR DESCRIPTION
Apps-engine dependency was locked to a version to prevent breaking installation when a release upstream was faulty.

Problem is fixed, we don't need to avoid newer versions anymore