### PR TITLE
fix: readme file was being created in the wrong directory

### DIFF
--- a/src/misc/appCreator.ts
+++ b/src/misc/appCreator.ts
@@ -70,7 +70,7 @@ export class AppCreator {
     // tslint:disable:max-line-length
     private createdReadme(): void {
         const toWrite = readmeTemplate(this.fd.info.name, this.fd.info.description);
-        fs.writeFileSync('README.md', toWrite, 'utf8');
+        fs.writeFileSync(this.fd.mergeWithFolder('README.md'), toWrite, 'utf8');
     }
 
     private createTsConfig(): void {


### PR DESCRIPTION
When running the `create` subcommand, the README.md file was being created outside of the app directory