### PR TITLE
fix(packager): normalize Windows path separators in zip entries

### DIFF
--- a/src/misc/appPackager.ts
+++ b/src/misc/appPackager.ts
@@ -59,7 +59,7 @@ export class AppPackager {
         zip.addBuffer(Buffer.from(JSON.stringify(AppPackager.PackagerInfo)), '.packagedby', { compress: true });
 
         for (const realPath of matches) {
-            const zipPath = path.relative(this.fd.folder, realPath);
+            const zipPath = path.relative(this.fd.folder, realPath).replace(/\\/g, '/');
             const fileStat = await fs.stat(realPath);
 
             const options: Partial<Yazl.Options> = {


### PR DESCRIPTION
# Fix: Windows deployment - normalize TypeScript import paths

## Problem
When deploying Rocket.Chat Apps on **Windows** using `rc-apps deploy`, the packaging step fails with a TypeScript error:
File 'RoomPersistence.ts' not found.

- The project compiles correctly with `tsc`.
- Deploys fine on macOS.
- The error occurs only when the main app entry imports additional modules.
- Root cause: the CLI Language Service cannot resolve Windows-style `\` paths during packaging.

## Solution
- Normalize all module paths in the packager to use **POSIX-style `/` separators**.
- Ensures TypeScript can locate all source files on Windows.
- Cross-platform safe: macOS and Linux deployments remain unaffected.
- But this thing require #179 to be done , as it give Cross-Platforem safe work with help of remref (in Windows):
-   "postpack": "rimraf oclif.manifest.json",
    "prepack": "rimraf lib && tsc && oclif-dev manifest && oclif-dev readme",
    "prepare": "rimraf lib && tsc",

## Impact
- Windows deployments now succeed even with additional module imports in the main app entry.
- Deployment behavior is consistent across **Windows, macOS, and Linux**.

## Testing
- Verified packaging succeeds on Windows with module imports.
- Verified macOS deployment continues to work as expected.

## Related Issue
- Fixes #177 

<img width="1684" height="166" alt="Screenshot 2026-03-15 223841" src="https://github.com/user-attachments/assets/742c1647-10b7-40a5-90f7-0238f2b19ad4" />

### Final Result
<img width="1387" height="248" alt="Screenshot 2026-03-15 223552" src="https://github.com/user-attachments/assets/9b4be2ff-71d1-431a-aef4-54ced1538542" />

