### PR TITLE
fix: Map short options in generate command to prevent silent exit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6129,6 +6129,7 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
       "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
@@ -6286,6 +6287,7 @@
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
       "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -6351,6 +6353,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11470,6 +11473,7 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
       "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
@@ -11587,6 +11591,7 @@
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
       "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.8.1"
       }
@@ -11633,7 +11638,8 @@
     "typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true
     },
     "uglify-js": {
       "version": "3.6.9",

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -33,6 +33,14 @@ export default class Generate extends Command {
             'Slash Command Extension',
             'Settings Extension',
         ];
+
+        if (option) {
+            const index = ['a', 'b', 'c'].indexOf(option);
+            if (index !== -1) {
+                option = categories[index];
+            }
+        }
+
         if (!option) {
             inquirer.registerPrompt('checkbox-plus', require('inquirer-checkbox-plus-prompt'));
             const result = await inquirer.prompt([{

--- a/test/commands/generate.test.ts
+++ b/test/commands/generate.test.ts
@@ -1,0 +1,15 @@
+import { test } from '@oclif/test';
+
+describe('generate', () => {
+    test
+        .stdout()
+        .command(['generate', '-o', 'a'])
+        .exit(2)
+        .it('runs generate with option "a" and correctly attempts to find app.json');
+        
+    test
+        .stdout()
+        .command(['generate', '-o', 'x'])
+        .exit(2)
+        .it('fails when passing an invalid option not in a,b,c');
+});


### PR DESCRIPTION
This PR addresses a bug in the rc-apps generate command where using the shorthand -o flags (a, b, or c) resulted in the CLI exiting silently without providing an error or generating the requested boilerplate files. 

This has been resolved by mapping the valid single-character inputs from flags.options back to their full category equivalents before evaluating the switch block. This significantly improves the developer experience by ensuring boilerplate templates generate as expected when using the CLI arguments.

### Changes Made
* Updated src/commands/generate.ts to map the short-letter options (a, b, c) to the categories array strings.
* * Added a new unit test in test/commands/generate.test.ts to verify the execution of valid and invalid shorthand flags.