### PR TITLE
Add app type selection prompt to create command

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -43,6 +43,14 @@ export default class Create extends Command {
         this.log('We need some information first:');
         this.log('');
 
+        const appType = await cli.prompt(
+            chalk.bold('   App Type (chatbot/integration)'),
+            { default: 'chatbot' }
+        );
+
+        this.log(`Selected App Type: ${chalk.green(appType)}`);
+        this.log('');
+
         const { flags } = this.parse(Create);
         info.name = flags.name ? flags.name : await cli.prompt(chalk.bold('   App Name'));
         info.nameSlug = VariousUtils.slugify(info.name);


### PR DESCRIPTION
## Description
This PR adds a simple CLI prompt during app creation to let users select their app type.

## Changes
- Added interactive prompt asking for app type: "chatbot" or "integration"
- Default value is "chatbot"
- Displays the selected app type to the user

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
```bash
npm run build
rc-apps create