### PR TITLE
Add app category selection prompt to create command

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -43,6 +43,14 @@ export default class Create extends Command {
         this.log('We need some information first:');
         this.log('');
 
+        const appType = await cli.prompt(
+            chalk.bold('   App Type (chatbot/integration)'),
+            { default: 'chatbot' }
+        );
+
+        this.log(`Selected App Type: ${chalk.green(appType)}`);
+        this.log('');
+
         const { flags } = this.parse(Create);
         info.name = flags.name ? flags.name : await cli.prompt(chalk.bold('   App Name'));
         info.nameSlug = VariousUtils.slugify(info.name);

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -51,6 +51,14 @@ export default class Create extends Command {
         this.log(`Selected App Type: ${chalk.green(appType)}`);
         this.log('');
 
+        const appCategory = await cli.prompt(
+            chalk.bold('   App Category (chatbot/integration/other)'),
+            { default: 'other' }
+        );
+
+        this.log(`Selected Category: ${chalk.green(appCategory)}`);
+        this.log('');
+
         const { flags } = this.parse(Create);
         info.name = flags.name ? flags.name : await cli.prompt(chalk.bold('   App Name'));
         info.nameSlug = VariousUtils.slugify(info.name);


### PR DESCRIPTION
## Description
Adds an interactive prompt for users to select an app category during app creation.

## Changes
- Added app category selection prompt (chatbot/integration/other)
- Default value is "other"
- Displays the selected category to the user

## Type of Change
- [x] New feature (non-breaking change)

## Testing
```bash
npm run build
rc-apps create