### PR TITLE
Add cli flagsAdd CLI flags to support non-interactive app creation

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -23,6 +23,8 @@ export default class Create extends Command {
         author: flags.string({char: 'a', description: 'Author\'s name'}),
         homepage: flags.string({char: 'H', description: 'Author\'s or app\'s home page'}),
         support: flags.string({char: 's', description: 'URL or email address to get support for the app'}),
+        type: flags.string({char: 't', description: 'App type (chatbot/integration)'}),
+        category: flags.string({char: 'c', description: 'App category (chatbot/integration/other)'}),
     };
 
     public async run() {
@@ -43,7 +45,9 @@ export default class Create extends Command {
         this.log('We need some information first:');
         this.log('');
 
-        const appType = await cli.prompt(
+        const { flags } = this.parse(Create);
+
+        const appType = flags.type ? flags.type.toLowerCase() : await cli.prompt(
             chalk.bold('   App Type (chatbot/integration)'),
             { default: 'chatbot' }
         );
@@ -51,7 +55,15 @@ export default class Create extends Command {
         this.log(`Selected App Type: ${chalk.green(appType)}`);
         this.log('');
 
-        const { flags } = this.parse(Create);
+        const appCategory = flags.category ? flags.category.toLowerCase() : await cli.prompt(
+            chalk.bold('   App Category (chatbot/integration/other)'),
+            { default: 'other' }
+        ).then((input: string) => input.toLowerCase());
+
+        this.log(`Selected Category: ${chalk.green(appCategory)}`);
+        this.log('');
+
+        this.log(chalk.gray('(Use lowercase letters, numbers, and hyphens only, e.g., my-app)'));
         info.name = flags.name ? flags.name : await cli.prompt(chalk.bold('   App Name'));
         info.nameSlug = VariousUtils.slugify(info.name);
         info.classFile = `${ pascalCase(info.name) }App.ts`;

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -43,6 +43,14 @@ export default class Create extends Command {
         this.log('We need some information first:');
         this.log('');
 
+        const appType = await cli.prompt(
+            chalk.bold('   App Type (chatbot/integration)'),
+            { default: 'chatbot' }
+        );
+
+        this.log(`Selected App Type: ${chalk.green(appType)}`);
+        this.log('');
+
         const { flags } = this.parse(Create);
         info.name = flags.name ? flags.name : await cli.prompt(chalk.bold('   App Name'));
         info.nameSlug = VariousUtils.slugify(info.name);


### PR DESCRIPTION
## Description
Adds support for CLI flags (`--type` and `--category`) to allow non-interactive app creation, enabling automation and scripting scenarios.

## Problem
Currently the CLI is fully interactive:
- No way to automate app creation
- Scripts/CI pipelines can't use it
- Similar to modern CLI tools that support both modes

## Solution
Added optional flags:
- `--type` (or `-t`): App type (chatbot/integration)
- `--category` (or `-c`): App category (chatbot/integration/other)

If flags provided → uses them (non-interactive)
If flags absent → falls back to prompts (interactive)

## Changes
- Added 2 new flags to static flags definition
- Moved flag parsing before prompts
- Updated appType prompt to use flag if provided
- Added appCategory prompt with same pattern
- Maintains backward compatibility

## Type of Change
- [x] New feature (non-breaking)

## Usage Examples

### Interactive (existing):
```bash
rc-apps create