### PR TITLE
fix: propagate npm install errors in rc-apps create

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -62,7 +62,13 @@ export default class Create extends Command {
         fd.setFolder(folder);
 
         const creator = new AppCreator(fd, this);
-        await creator.writeFiles();
+
+        try {
+            await creator.writeFiles();
+        } catch (e) {
+            this.error(e && e.message ? e.message : String(e));
+            return;
+        }
 
         try {
             await fd.readInfoFile();

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -147,7 +147,7 @@ export default class Submit extends Command {
                 searchable: true,
                 validate: (answer: Array<string>) => {
                     if (answer.length === 0) {
-                        return 'You must choose at least one color.';
+                        return 'You must choose at least one category.';
                     }
 
                     return true;

--- a/src/misc/appCreator.ts
+++ b/src/misc/appCreator.ts
@@ -104,14 +104,20 @@ export class AppCreator {
         fs.writeFileSync(this.fd.mergeWithFolder('.vscode/extensions.json'), toWrite, 'utf8');
     }
 
+    /**
+     * Runs `npm install` inside the newly created App directory.
+     * Rejects with a descriptive error including npm's stderr output so
+     * developers can immediately diagnose the root cause of the failure.
+     */
     // tslint:disable-next-line:promise-function-async
     private runNpmInstall(): Promise<void> {
         return new Promise((resolve, reject) => {
             exec('npm install', {
                 cwd: this.fd.folder,
-            }, (e) => {
+            }, (e, _stdout, stderr) => {
                 if (e) {
-                    reject();
+                    const detail = (stderr && stderr.trim()) ? stderr.trim() : e.message;
+                    reject(new Error(`npm install failed:\n${detail}`));
                     return;
                 }
 


### PR DESCRIPTION
When npm install fails during app scaffolding, the previous reject() call passed no argument, making the rejection reason undefined and the CLI output completely useless.

- Pass stderr (or exec error message) to reject() with a clear message
- Wrap writeFiles() in try/catch in create.ts so failures surface correctly
- Fix copy-paste validation message: 'color' -> 'category' in submit.ts